### PR TITLE
chore: add support for dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,13 @@ name = "scw_serverless"
 version = "0.0.1"
 requires-python = ">=3.9"
 dependencies = [
-    "click==8.1.3",
-    "PyYAML==6.0",
-    "scaleway~=1.0",
-    "setuptools",
-    "requests==2.28.1",
-    "typing_extensions",
+    "click >= 8",
+    "PyYAML >= 6",
+    "scaleway >= 0.2",
+    # Requires support for pyproject.toml
+    "setuptools >= 61",
+    "requests >= 2",
+    "typing_extensions; python_version<'3.11'",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-pytest==7.1.3
-pytest-xdist==2.5.0
-pylint==2.15.5
-pylint-per-file-ignores==1.0.0
+pytest==7.2.0
+pytest-xdist==3.1.0
+pylint==2.15.9
+pylint-per-file-ignores==1.1.0
 
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 click==8.1.3
 PyYAML==6.0
-scaleway==0.0.12
-setuptools==65.3.0
+scaleway==0.2.0
+setuptools==65.6.3
 requests==2.28.1
-typing-extensions==4.3.0
-prettytable==3.4.1
+typing_extensions==4.4.0

--- a/scw_serverless/app.py
+++ b/scw_serverless/app.py
@@ -1,7 +1,11 @@
-from typing import Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 
-from typing_extensions import Unpack
-
+if TYPE_CHECKING:
+    try:
+        from typing import Unpack
+    except ImportError:
+        from typing_extensions import Unpack
+# pylint: disable=wrong-import-position # Conditional import considered a statement
 from scw_serverless.config.function import Function, FunctionKwargs
 from scw_serverless.config.route import HTTPMethod
 from scw_serverless.triggers import CronTrigger

--- a/scw_serverless/config/function.py
+++ b/scw_serverless/config/function.py
@@ -1,10 +1,15 @@
 import sys
 from dataclasses import dataclass
-from typing import Callable, List, Literal, Optional, TypedDict
+from typing import TYPE_CHECKING, Callable, List, Literal, Optional, TypedDict
 
 import scaleway.function.v1beta1 as sdk
-from typing_extensions import NotRequired
 
+if TYPE_CHECKING:
+    try:
+        from typing import NotRequired
+    except ImportError:
+        from typing_extensions import NotRequired
+# pylint: disable=wrong-import-position # Conditional import considered a statement
 from scw_serverless.config.route import GatewayRoute, HTTPMethod
 from scw_serverless.config.utils import _SerializableDataClass
 from scw_serverless.logger import get_logger

--- a/scw_serverless/utils/config.py
+++ b/scw_serverless/utils/config.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from typing_extensions import Self
 
 DEFAULT_CONFIG_PATH = "~/.config/scw/py_api.yaml"
 
@@ -15,7 +14,7 @@ class Config:
     api_gw_host: Optional[str] = None  # Host for the API Gateway controller api
     gateway_id: Optional[str] = None  # Default API Gateway uuid
 
-    def update_from_config_file(self, config_path: Optional[str] = None) -> Self:
+    def update_from_config_file(self, config_path: Optional[str] = None) -> "Config":
         """Update an existing config instance whith values passed via a config file."""
         config_path = config_path if config_path else DEFAULT_CONFIG_PATH
         config_path = Path(DEFAULT_CONFIG_PATH).expanduser()


### PR DESCRIPTION
This PR adds a dependabot.yml file to configure dependabots alerts for package updates. We recently received a dependabot security alert, so it made sense to configure this now.

In addition, the dependencies  were updated to their latest version after a brief test confirmed that the cli was still working.
I unpinned the dependencies in the pyproject.toml. It's still unclear what's considered best practices here. Usually, you do not want to pin the dependencies for a library but as this project contains both a cli and a library it's not exactly clear what's more appropriate here. I would really like to split both inside separate modules, but it's not exactly easy to do so. This would also solve the issue of us installing random junk inside the client function, like click.

I've also decided to conditionally import typing_extensions since it's not always used.
