### PR TITLE
chore: rename repo to serverless-api-framework-python

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,14 +1,17 @@
-# Contribute to `serverless-api-project`
+# Contribute to `serverless-api-framework-python`
 
-`serverless-api-project` is MIT licensed accepts contributions via GitHub. This document will cover how to contribute to the project and report issues.
+`serverless-api-framework-python` is MIT licensed accepts contributions via GitHub. This document will cover how to contribute to the project and report issues.
 
 ## Topics
 
-- [Reporting Security Issues](#reporting-security-issues)
-- [Reporting Issues](#reporting-issues)
-- [Suggesting feature](#suggesting-feature)
-- [Contributing Code](#contributing-code)
-- [Community Guidelines](#community-guidelines)
+- [Contribute to `serverless-api-framework-python`](#contribute-to-serverless-api-framework-python)
+  - [Topics](#topics)
+  - [Reporting security issues](#reporting-security-issues)
+  - [Reporting issues](#reporting-issues)
+  - [Suggesting a feature](#suggesting-a-feature)
+    - [Submit code](#submit-code)
+    - [Pull Request Guidelines](#pull-request-guidelines)
+  - [Community guidelines](#community-guidelines)
 
 ## Reporting security issues
 
@@ -21,7 +24,7 @@ We always appreciate a well-written, thorough bug report, and will thank you for
 Before opening a new issue, we appreciate you reviewing open issues to see if there are any similar requests.
 If there is a match, thumbs up the issue with a 👍 and leave a comment if you have additional information.
 
-When reporting an issue, please include the version of `serverless-api-project`, your os and the version of python you are using.
+When reporting an issue, please include the version of `serverless-api-framework-python`, your os and the version of python you are using.
 
 ## Suggesting a feature
 
@@ -29,7 +32,7 @@ When requesting a feature, some of the questions we want to answer are:
 
 - What value does this feature bring to end users?
 - How urgent is the need (nice to have feature or need to have)?
-- Does this align with the goals of `serverless-api-project`?
+- Does this align with the goals of `serverless-api-framework-python`?
 
 ### Submit code
 
@@ -39,7 +42,7 @@ To submit code:
 - Create a topic branch from where you want to base your work (usually main)
 - Add tests to cover contributed code
 - Push your commit(s) to your topic branch on your fork
-- Open a pull request against `serverless-api-project` `main` branch that follows [PR guidelines](#pull-request-guidelines)
+- Open a pull request against `serverless-api-framework-python` `main` branch that follows [PR guidelines](#pull-request-guidelines)
 
 If you have questions or comments on your code, feel free to correct these in your branch through new commits.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Serverless API Framework
 
 [![PyPI version](https://badge.fury.io/py/scw-serverless.svg)](https://badge.fury.io/py/scw-serverless)
-[![Documentation Status](https://readthedocs.org/projects/serverless-api-project/badge/?version=latest)](https://serverless-api-project.readthedocs.io/en/latest/?badge=latest)
-[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/scaleway/serverless-api-project/main.svg)](https://results.pre-commit.ci/latest/github/scaleway/serverless-api-project/main)
+[![Documentation Status](https://readthedocs.org/projects/serverless-api-framework-python/badge/?version=latest)](https://serverless-api-framework-python.readthedocs.io/en/latest/?badge=latest)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/scaleway/serverless-api-framework-python/main.svg)](https://results.pre-commit.ci/latest/github/scaleway/serverless-api-framework-python/main)
 
-Serverless API Framework is a tool that lets you write and deploy serverless functions in python.
+Serverless API Framework is a tool that lets you write and deploy serverless functions in Python.
 It bridges your code with the deployment configuration to make it a breeze to work with serverless functions.
 
 Starts by defining a simple Python function:
@@ -41,7 +41,7 @@ scw-serverless --help
 
 ### Writing and configuring functions
 
-You can transform your python functions into serverless functions by using decorators:
+You can transform your Python functions into serverless functions by using decorators:
 
 ```python
 import os
@@ -57,7 +57,7 @@ def hello_world(event, context):
 ```
 
 The configuration is done by passing arguments to the decorator.
-To view which arguments are supported, head over to this [documentation](https://serverless-api-project.readthedocs.io/) page.
+To view which arguments are supported, head over to this [documentation](https://serverless-api-framework-python.readthedocs.io/) page.
 
 When you are ready, you can deploy your function with the `scw-serverless` CLI tool:
 
@@ -69,8 +69,10 @@ The tool will use your Scaleway credentials from your environment and config fil
 
 ## What’s Next?
 
-To learn more about the framework, have a look at the [documentation](https://serverless-api-project.readthedocs.io/).
-If you want to see it in action, we provide some [examples](https://github.com/scaleway/serverless-api-project/tree/main/examples) to get you started.
+To learn more about the framework, have a look at the [documentation](https://serverless-api-framework-python.readthedocs.io/).
+If you want to see it in action, we provide some [examples](https://github.com/scaleway/serverless-api-framework-python-python/tree/main/examples) to get you started.
+
+To run your Python functions locally, check out [Scaleway Functions Python](https://github.com/scaleway/serverless-functions-python).
 
 ## Contributing
 

--- a/docs/source/examples/cron.md
+++ b/docs/source/examples/cron.md
@@ -2,7 +2,7 @@
 
 A Cron example to showcase the `schedule` decator.
 
-## [Source](https://github.com/scaleway/serverless-api-project/blob/main/examples/cron/handler.py)
+## [Source](https://github.com/scaleway/serverless-api-framework-python/blob/main/examples/cron/handler.py)
 
 ```{literalinclude} ../../../examples/cron/handler.py
 ```

--- a/docs/source/examples/github_actions.md
+++ b/docs/source/examples/github_actions.md
@@ -1,7 +1,7 @@
 ```{include} ../../../examples/github_actions/README.md
 ```
 
-## [Source](https://github.com/scaleway/serverless-api-project/blob/main/examples/pr_notifier/notifier.py)
+## [Source](https://github.com/scaleway/serverless-api-framework-python/blob/main/examples/pr_notifier/notifier.py)
 
 ```{literalinclude} ../../../examples/github_actions/deploy.yml
 ---

--- a/docs/source/examples/hello_world.md
+++ b/docs/source/examples/hello_world.md
@@ -2,7 +2,7 @@
 
 A simple "Hello World!" example to get you started.
 
-## [Source](https://github.com/scaleway/serverless-api-project/blob/main/examples/hello_world/handler.py)
+## [Source](https://github.com/scaleway/serverless-api-framework-python/blob/main/examples/hello_world/handler.py)
 
 ```{literalinclude} ../../../examples/hello_world/handler.py
 ```

--- a/docs/source/examples/multiple_modules.md
+++ b/docs/source/examples/multiple_modules.md
@@ -1,7 +1,7 @@
 ```{include} ../../../examples/multiple_modules/README.md
 ```
 
-## [Sources](https://github.com/scaleway/serverless-api-project/blob/main/examples/multiple_modules/app.py)
+## [Sources](https://github.com/scaleway/serverless-api-framework-python/blob/main/examples/multiple_modules/app.py)
 
 ```{literalinclude} ../../../examples/multiple_modules/app.py
 ```

--- a/docs/source/examples/pr_notifier.md
+++ b/docs/source/examples/pr_notifier.md
@@ -1,7 +1,7 @@
 ```{include} ../../../examples/pr_notifier/README.md
 ```
 
-## [Source](https://github.com/scaleway/serverless-api-project/blob/main/examples/pr_notifier/notifier.py)
+## [Source](https://github.com/scaleway/serverless-api-framework-python/blob/main/examples/pr_notifier/notifier.py)
 
 ```{literalinclude} ../../../examples/pr_notifier/notifier.py
 ```

--- a/examples/github_actions/README.md
+++ b/examples/github_actions/README.md
@@ -1,4 +1,4 @@
-# [Deploying using Github Actions](https://github.com/scaleway/serverless-api-project/tree/main/examples/github_actions)
+# [Deploying using Github Actions](https://github.com/scaleway/serverless-api-framework-python/tree/main/examples/github_actions)
 
 This example provides a simple Github Action configuration file to get you started on deploying with `scw_serverless` in your CI/CD pipelines.
 

--- a/examples/multiple_modules/README.md
+++ b/examples/multiple_modules/README.md
@@ -1,4 +1,4 @@
-# [Multiple Modules](https://github.com/scaleway/serverless-api-project/tree/main/examples/multiple_modules)
+# [Multiple Modules](https://github.com/scaleway/serverless-api-framework-python/tree/main/examples/multiple_modules)
 
 An app to upload and query files to S3 Glacier on Scaleway split in multiple modules.
 

--- a/examples/pr_notifier/README.md
+++ b/examples/pr_notifier/README.md
@@ -1,4 +1,4 @@
-# [Pull Requests Notifier](https://github.com/scaleway/serverless-api-project/tree/main/examples/pr_notifier)
+# [Pull Requests Notifier](https://github.com/scaleway/serverless-api-framework-python/tree/main/examples/pr_notifier)
 
 A simple Slack bot to notify on new pull requests using `scw_serverless` for deployment. Compatible with Github and Gitlab.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = "Framework for writing serverless APIs in Python, using Scaleway f
 authors = ["Scaleway Serverless Team <opensource@scaleway.com>"]
 readme = "README.md"
 license = "MIT"
-repository = "https://github.com/scaleway/serverless-api-project"
-documentation = "https://serverless-api-project.readthedocs.io/en/latest/"
+repository = "https://github.com/scaleway/serverless-api-framework-python-python"
+documentation = "https://serverless-api-framework-python.readthedocs.io/en/latest/"
 keywords = ["serverless", "scaleway", "functions", "cloud", "faas"]
 
 # Should be one of:


### PR DESCRIPTION
## Summary

**_What's changed?_**

All names referring to API-project were changed to API-framework to coincide with the updated GitHub repo name.

**_Why do we need this?_**

Improve clarity and conform to universal language.

**_How have you tested it?_**

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
