### PR TITLE
chore(ci): remove self-hosted runners

### DIFF
--- a/.github/workflows/integration-gateway.yml
+++ b/.github/workflows/integration-gateway.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   setup-gateway:
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     container: python:3.11-bookworm
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +31,7 @@ jobs:
   run-tests:
     needs:
       - setup-gateway
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     container: python:3.11-bookworm
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
 
   teardown-gateway:
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     container: python:3.11-bookworm
     needs:
       - run-tests

--- a/.github/workflows/pytest-integration.yml
+++ b/.github/workflows/pytest-integration.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     container: python:3.11-bookworm
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     container: python:3.11-bookworm
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-22.04
     container: python:3.11-bookworm
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

**_What's changed?_**

Revert to using Github runners.

**_Why do we need this?_**

Self-hosted runners no longer online.

**_How have you tested it?_**

Pipelines.

## Checklist

- [x] I have reviewed this myself
- [x] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation